### PR TITLE
Remove relative directory prefix in pokemonthink

### DIFF
--- a/pokemonthink.sh
+++ b/pokemonthink.sh
@@ -4,4 +4,4 @@
 # Call pokemonsay with the think option.
 #
 
-./pokemonsay.sh --think $@
+pokemonsay.sh --think $@


### PR DESCRIPTION
Fails with a home-brew installation unless you remove the "./" from the call to pokemonsay assuming the command will be in PATH.