### PR TITLE
Fix about shuf command in MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It may be necessary to logout and login back again to have `pokemonsay` in you `
 You can install `pokemonsay` through Homebrew. It is pretty straightforward:
 
 ```sh
+$ brew install coreutils # to use gshuf
 $ brew tap possatti/possatti
 $ brew install pokemonsay
 ```

--- a/pokemonsay.sh
+++ b/pokemonsay.sh
@@ -106,13 +106,20 @@ if [ -n "$WORD_WRAP" ]; then
 	word_wrap="-W $WORD_WRAP"
 fi
 
+# Support MacOS 
+if [ "$(uname)" == 'Darwin' ]; then
+  SHUF=gshuf
+else
+  SHUF=gshuf
+fi
+
 # Define which pokemon should be displayed.
 if [ -n "$POKEMON_NAME" ]; then
 	pokemon_cow=$(find $pokemon_path -name "$POKEMON_NAME.cow")
 elif [ -n "$COW_FILE" ]; then
 	pokemon_cow="$COW_FILE"
 else
-	pokemon_cow=$(find $pokemon_path -name "*.cow" | shuf -n1)
+	pokemon_cow=$(find $pokemon_path -name "*.cow" | $SHUF -n1)
 fi
 
 # Get the pokemon name.

--- a/pokemonsay.sh
+++ b/pokemonsay.sh
@@ -110,7 +110,7 @@ fi
 if [ "$(uname)" == 'Darwin' ]; then
   SHUF=gshuf
 else
-  SHUF=gshuf
+  SHUF=shuf
 fi
 
 # Define which pokemon should be displayed.


### PR DESCRIPTION
# Purpose
Resolve this issue
https://github.com/possatti/pokemonsay/issues/7
I think MacOS doesn't support `shuf`, but instead, `gshuf` is in MacOS as coreutils
Thanks 🙇 🙇 